### PR TITLE
Dynamically run jobs based on file extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
             <artifactId>xstream</artifactId>
             <version>1.4.12</version>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.7</version>
+        </dependency>
 
     </dependencies>
     <build>

--- a/src/main/java/com/dzmudziak/fileimport/batch/BatchConfiguration.java
+++ b/src/main/java/com/dzmudziak/fileimport/batch/BatchConfiguration.java
@@ -1,28 +1,31 @@
 package com.dzmudziak.fileimport.batch;
 
-import com.dzmudziak.fileimport.config.ConfigProperties;
 import com.dzmudziak.fileimport.domain.Customer;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.item.file.FlatFileItemReader;
 import org.springframework.batch.item.file.mapping.DefaultLineMapper;
 import org.springframework.batch.item.file.transform.DefaultFieldSet;
 import org.springframework.batch.item.xml.StaxEventItemReader;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.oxm.xstream.XStreamMarshaller;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+@SuppressWarnings("ConstantConditions")
 @Configuration
 @EnableBatchProcessing
 public class BatchConfiguration {
@@ -31,25 +34,24 @@ public class BatchConfiguration {
     private final StepBuilderFactory stepBuilderFactory;
     private final CustomerItemWriter customerItemWriter;
     private final CustomerConverter customerConverter;
-    private final ConfigProperties configProperties;
 
     @Autowired
     public BatchConfiguration(CustomerFieldSetMapper customerFieldSetMapper,
                               JobBuilderFactory jobBuilderFactory,
                               StepBuilderFactory stepBuilderFactory,
-                              CustomerItemWriter customerItemWriter, CustomerConverter customerConverter, ConfigProperties configProperties) {
+                              CustomerItemWriter customerItemWriter, CustomerConverter customerConverter) {
         this.customerFieldSetMapper = customerFieldSetMapper;
         this.jobBuilderFactory = jobBuilderFactory;
         this.stepBuilderFactory = stepBuilderFactory;
         this.customerItemWriter = customerItemWriter;
         this.customerConverter = customerConverter;
-        this.configProperties = configProperties;
     }
 
     @Bean
-    public FlatFileItemReader<Customer> csvReader() {
+    @StepScope
+    public FlatFileItemReader<Customer> csvReader(@Value("#{jobParameters['filePath']}") String filePath) {
         FlatFileItemReader<Customer> reader = new FlatFileItemReader<>();
-        reader.setResource(new ClassPathResource(configProperties.getCsvFile()));
+        reader.setResource(new FileSystemResource(Paths.get(filePath)));
         reader.setEncoding(StandardCharsets.UTF_8.name());
         reader.setLineMapper(new DefaultLineMapper<>() {
             {
@@ -61,16 +63,17 @@ public class BatchConfiguration {
     }
 
     @Bean
-    public StaxEventItemReader<Customer> xmlReader() {
+    @StepScope
+    public StaxEventItemReader<Customer> xmlReader(@Value("#{jobParameters['filePath']}") String filePath) {
         StaxEventItemReader<Customer> reader = new StaxEventItemReader<>();
-        reader.setResource(new ClassPathResource(configProperties.getXmlFile()));
+        reader.setResource(new FileSystemResource(Paths.get(filePath)));
         reader.setFragmentRootElementName("person");
-        reader.setUnmarshaller(tradeMarshaller());
+        reader.setUnmarshaller(customerMarshaller());
         return reader;
     }
 
     @Bean
-    public XStreamMarshaller tradeMarshaller() {
+    public XStreamMarshaller customerMarshaller() {
         Map<String, Class<?>> aliases = new HashMap<>();
         aliases.put("person", Customer.class);
         XStreamMarshaller marshaller = new XStreamMarshaller();
@@ -81,11 +84,19 @@ public class BatchConfiguration {
 
 
     @Bean
-    public Job importCustomerJob() {
+    public Job importXML() {
         return jobBuilderFactory.get("importCustomerJob")
                 .incrementer(new RunIdIncrementer())
                 .start(xmlFileStep())
-                .next(flatFileStep())
+                .build();
+    }
+
+
+    @Bean
+    public Job importCSV() {
+        return jobBuilderFactory.get("importCustomerJob")
+                .incrementer(new RunIdIncrementer())
+                .start(flatFileStep())
                 .build();
     }
 
@@ -93,7 +104,7 @@ public class BatchConfiguration {
     public Step flatFileStep() {
         return stepBuilderFactory.get("flatFileStep")
                 .<Customer, Customer>chunk(10)
-                .reader(csvReader())
+                .reader(csvReader(null))
                 .writer(customerItemWriter)
                 .build();
     }
@@ -102,7 +113,7 @@ public class BatchConfiguration {
     public Step xmlFileStep() {
         return stepBuilderFactory.get("xmlFileStep")
                 .<Customer, Customer>chunk(10)
-                .reader(xmlReader())
+                .reader(xmlReader(null))
                 .writer(customerItemWriter)
                 .build();
     }

--- a/src/main/java/com/dzmudziak/fileimport/batch/CustomJobLauncher.java
+++ b/src/main/java/com/dzmudziak/fileimport/batch/CustomJobLauncher.java
@@ -1,0 +1,39 @@
+package com.dzmudziak.fileimport.batch;
+
+import com.dzmudziak.fileimport.config.ConfigProperties;
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomJobLauncher implements CommandLineRunner {
+    private final JobLauncher jobLauncher;
+    private final JobFactory jobFactory;
+    private final ConfigProperties configProperties;
+
+    @Autowired
+    public CustomJobLauncher(JobLauncher jobLauncher, JobFactory jobFactory, ConfigProperties configProperties) {
+        this.jobLauncher = jobLauncher;
+        this.jobFactory = jobFactory;
+        this.configProperties = configProperties;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        JobParametersBuilder builder = new JobParametersBuilder();
+        JobParameters jobParameters = builder
+                .addString("filePath", configProperties.getFilePath())
+                .toJobParameters();
+        String extension = FilenameUtils.getExtension(configProperties.getFilePath());
+        Job job = jobFactory.getJob(extension);
+        if (job == null) {
+            System.out.println("No valid job selected - file extension not recognized.");
+        }
+        jobLauncher.run(job, jobParameters);
+    }
+}

--- a/src/main/java/com/dzmudziak/fileimport/batch/JobFactory.java
+++ b/src/main/java/com/dzmudziak/fileimport/batch/JobFactory.java
@@ -1,0 +1,32 @@
+package com.dzmudziak.fileimport.batch;
+
+import org.springframework.batch.core.Job;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobFactory {
+    private static final String CSV = "CSV";
+    private static final String TXT = "TXT";
+    private static final String XML = "XML";
+
+    private final Job csvJob;
+    private final Job xmlJob;
+
+    @Autowired
+    public JobFactory(@Qualifier("importCSV") Job csvJob, @Qualifier("importXML") Job xmlJob) {
+        this.csvJob = csvJob;
+        this.xmlJob = xmlJob;
+    }
+
+    Job getJob(String fileType) {
+        if (CSV.equalsIgnoreCase(fileType) || TXT.equalsIgnoreCase(fileType)) {
+            return csvJob;
+        } else if (XML.equalsIgnoreCase(fileType)) {
+            return xmlJob;
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/dzmudziak/fileimport/config/ConfigProperties.java
+++ b/src/main/java/com/dzmudziak/fileimport/config/ConfigProperties.java
@@ -9,46 +9,37 @@ public class ConfigProperties {
     private String emailPattern = "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}";
     private String phonePattern = "^((\\(\\d{3}\\))|\\d{3})[- .]?\\d{3}[- .]?\\d{3}$";
     private String jabberPattern = "^[a-zA-Z]*$";
-    private String csvFile;
-    private String xmlFile;
+    private String filePath;
 
-    public String getCsvFile() {
-        return csvFile;
-    }
-
-    public void setCsvFile(String csvFile) {
-        this.csvFile = csvFile;
-    }
-
-    public String getXmlFile() {
-        return xmlFile;
-    }
-
-    public void setXmlFile(String xmlFile) {
-        this.xmlFile = xmlFile;
+    public String getEmailPattern() {
+        return emailPattern;
     }
 
     public void setEmailPattern(String emailPattern) {
         this.emailPattern = emailPattern;
     }
 
+    public String getPhonePattern() {
+        return phonePattern;
+    }
+
     public void setPhonePattern(String phonePattern) {
         this.phonePattern = phonePattern;
+    }
+
+    public String getJabberPattern() {
+        return jabberPattern;
     }
 
     public void setJabberPattern(String jabberPattern) {
         this.jabberPattern = jabberPattern;
     }
 
-    public String getEmailPattern() {
-        return emailPattern;
+    public String getFilePath() {
+        return filePath;
     }
 
-    public String getPhonePattern() {
-        return phonePattern;
-    }
-
-    public String getJabberPattern() {
-        return jabberPattern;
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,5 +7,6 @@ spring.h2.console.enabled=true
 app.emailPattern=[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}
 app.phonePattern=^((\\(\\d{3}\\))|\\d{3})[- .]?\\d{3}[- .]?\\d{3}$
 app.jabberPattern=^[a-zA-Z]*$
-app.csvFile=dane-osoby.txt
-app.xmlFile=dane-osoby.xml
+# This is supposed to be injected
+app.filePath=
+spring.batch.job.enabled=false

--- a/src/test/java/com/dzmudziak/fileimport/batch/JobFactoryTest.java
+++ b/src/test/java/com/dzmudziak/fileimport/batch/JobFactoryTest.java
@@ -1,0 +1,51 @@
+package com.dzmudziak.fileimport.batch;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.Job;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@SpringBootTest(classes = {JobFactory.class, Job.class})
+class JobFactoryTest {
+    @Autowired
+    private JobFactory jobFactory;
+
+    @Qualifier("importCSV")
+    @MockBean
+    private Job csvJob;
+
+    @Qualifier("importXML")
+    @MockBean
+    private Job xmlJob;
+
+
+    @Test
+    void shouldReturnXmlJob() {
+        Job job = jobFactory.getJob("XML");
+        assertEquals(xmlJob, job);
+    }
+
+    @Test
+    void shouldReturnCsvJobForCSV() {
+        Job job = jobFactory.getJob("CSV");
+        assertEquals(csvJob, job);
+    }
+
+    @Test
+    void shouldReturnCsvJobForTXT() {
+        Job job = jobFactory.getJob("TXT");
+        assertEquals(csvJob, job);
+    }
+
+    @Test
+    void shouldReturnNullForUnknownType() {
+        Job job = jobFactory.getJob("FOO");
+        assertNull(job);
+    }
+
+}


### PR DESCRIPTION
This commit changes the default functionality of Spring Batch - a Job is still ran at the start of the application, but now it applies custom logic to choose the correct Job.
An `app.filePath` property is now expected to be supplied at application start time, and no default is provided.
If the application fails to determine the Job to run, it will just run without running a job.

New dependencies:
- commons-io to get file extension